### PR TITLE
Updated RookSDK pod to 1.3.0

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2,12 +2,12 @@ PODS:
   - Flutter (1.0.0)
   - rook_sdk_apple_health (0.0.1):
     - Flutter
-    - RookSDK (= 1.2.6)
+    - RookSDK (= 1.3.0)
     - SwiftProtobuf (= 1.21.0)
-  - RookAppleHealth (1.3.4)
+  - RookAppleHealth (1.5.0)
   - RookConnectTransmission (1.2.7)
-  - RookSDK (1.2.6):
-    - RookAppleHealth (= 1.3.4)
+  - RookSDK (1.3.0):
+    - RookAppleHealth (= 1.5.0)
     - RookConnectTransmission (= 1.2.7)
     - RookUsersSDK (= 1.0.5)
   - RookUsersSDK (1.0.5)
@@ -38,10 +38,10 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
-  rook_sdk_apple_health: 2b4b38db210ed8ab97325fc5410c622c5301965a
-  RookAppleHealth: a5ecd485b79501d06c478b92b8243eea4fe03949
+  rook_sdk_apple_health: 21f80c91dffb50dbadb7160876a685de88755c24
+  RookAppleHealth: ffb4c7ed20470209fd25b473de58d9d101c06772
   RookConnectTransmission: b86ffb3f92376956cbdc4f5cde54e0d9bd963c0d
-  RookSDK: 3ae12414771b548cd33d4abf9551b05ba319321f
+  RookSDK: 4e4a11d3414164e4ec7fbdf8e670ae15fe8a965c
   RookUsersSDK: ad6d6ef984858403e7c6fdf7bd3f5ff3a55d666c
   SwiftProtobuf: afced68785854575756db965e9da52bbf3dc45e7
   url_launcher_ios: 08a3dfac5fb39e8759aeb0abbd5d9480f30fc8b4

--- a/packages/rook_sdk_apple_health/CHANGELOG.md
+++ b/packages/rook_sdk_apple_health/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.2.7
+## 0.3.0
 
 This changelog was moved to our official
 documentation [repository](https://github.com/RookeriesDevelopment/rook-flutter-sdk-doc/blob/main/rook_sdk_apple_health/CHANGELOG.md)

--- a/packages/rook_sdk_apple_health/ios/rook_sdk_apple_health.podspec
+++ b/packages/rook_sdk_apple_health/ios/rook_sdk_apple_health.podspec
@@ -15,7 +15,7 @@ A new Flutter plugin project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'RookSDK', '1.2.6'
+  s.dependency 'RookSDK', '1.3.0'
   s.dependency 'SwiftProtobuf', '1.21.0'
   s.platform = :ios, '13.0'
 

--- a/packages/rook_sdk_apple_health/playground/ios/Podfile.lock
+++ b/packages/rook_sdk_apple_health/playground/ios/Podfile.lock
@@ -4,12 +4,12 @@ PODS:
     - Flutter
   - rook_sdk_apple_health (0.0.1):
     - Flutter
-    - RookSDK (= 1.2.6)
+    - RookSDK (= 1.3.0)
     - SwiftProtobuf (= 1.21.0)
-  - RookAppleHealth (1.3.4)
+  - RookAppleHealth (1.5.0)
   - RookConnectTransmission (1.2.7)
-  - RookSDK (1.2.6):
-    - RookAppleHealth (= 1.3.4)
+  - RookSDK (1.3.0):
+    - RookAppleHealth (= 1.5.0)
     - RookConnectTransmission (= 1.2.7)
     - RookUsersSDK (= 1.0.5)
   - RookUsersSDK (1.0.5)
@@ -39,10 +39,10 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   integration_test: 13825b8a9334a850581300559b8839134b124670
-  rook_sdk_apple_health: 2b4b38db210ed8ab97325fc5410c622c5301965a
-  RookAppleHealth: a5ecd485b79501d06c478b92b8243eea4fe03949
+  rook_sdk_apple_health: 21f80c91dffb50dbadb7160876a685de88755c24
+  RookAppleHealth: ffb4c7ed20470209fd25b473de58d9d101c06772
   RookConnectTransmission: b86ffb3f92376956cbdc4f5cde54e0d9bd963c0d
-  RookSDK: 3ae12414771b548cd33d4abf9551b05ba319321f
+  RookSDK: 4e4a11d3414164e4ec7fbdf8e670ae15fe8a965c
   RookUsersSDK: ad6d6ef984858403e7c6fdf7bd3f5ff3a55d666c
   SwiftProtobuf: afced68785854575756db965e9da52bbf3dc45e7
 

--- a/packages/rook_sdk_apple_health/playground/pubspec.lock
+++ b/packages/rook_sdk_apple_health/playground/pubspec.lock
@@ -192,7 +192,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.2.6"
+    version: "0.2.7"
   rook_sdk_core:
     dependency: transitive
     description:

--- a/packages/rook_sdk_apple_health/pubspec.yaml
+++ b/packages/rook_sdk_apple_health/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rook_sdk_apple_health
 description: This package enables apps to extract and upload data from Apple Health.
-version: 0.2.7
+version: 0.3.0
 homepage: 'https://docs.tryrook.io/'
 platforms:
   ios:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -182,7 +182,7 @@ packages:
       path: "packages/rook_sdk_apple_health"
       relative: true
     source: path
-    version: "0.2.7"
+    version: "0.3.0"
   rook_sdk_core:
     dependency: "direct main"
     description:


### PR DESCRIPTION
# Pull request

## Summary

Updated RookSDK pod to 1.3.0, this version fixes a bug that caused a crash on some devices with IOS 17+.

## Type of change

- [x] Fix
- [ ] Feature
- [ ] Other [Change this text with the reason]
- [ ] This change requires a documentation update (If checked paste PR link on [Resources](#resources))

## Comments

Comments not related to the summary.

## Resources

Links to Issues, other repositories, etc.