### PR TITLE
Fixed crash on Android 13

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -67,5 +67,5 @@ flutter {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
-    implementation 'com.rookmotion.android:rook-sdk:0.8.0'
+    implementation 'com.rookmotion.android:rook-sdk:0.8.1'
 }

--- a/packages/rook_sdk_health_connect/CHANGELOG.md
+++ b/packages/rook_sdk_health_connect/CHANGELOG.md
@@ -1,3 +1,3 @@
-## 0.5.0
+## 0.5.1
 
 This changelog was moved to our official documentation [page](https://docs.tryrook.io/docs/category/sdks)

--- a/packages/rook_sdk_health_connect/android/build.gradle
+++ b/packages/rook_sdk_health_connect/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     ext {
         kotlinVersion = "1.8.10"
         gradleVersion = "8.1.2"
-        rookSdkVersion = "0.8.0"
+        rookSdkVersion = "0.8.1"
         protoVersion = "3.25.3"
         timber_version = "5.0.1"
 

--- a/packages/rook_sdk_health_connect/pubspec.yaml
+++ b/packages/rook_sdk_health_connect/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rook_sdk_health_connect
 description: This package enables apps to extract and upload data from Health Connect.
-version: 0.5.0
+version: 0.5.1
 homepage: 'https://docs.tryrook.io/'
 platforms:
   android:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -182,7 +182,7 @@ packages:
       path: "packages/rook_sdk_apple_health"
       relative: true
     source: path
-    version: "0.4.0"
+    version: "0.4.1"
   rook_sdk_core:
     dependency: "direct main"
     description:
@@ -196,7 +196,7 @@ packages:
       path: "packages/rook_sdk_health_connect"
       relative: true
     source: path
-    version: "0.5.0"
+    version: "0.5.1"
   sky_engine:
     dependency: transitive
     description: flutter


### PR DESCRIPTION
# Pull request

## Summary

Fixed crash on Android 13 or lower devices when using `rookYesterdaySync` without having health connect installed. (Upgraded rook-sdk to 0.8.1)

## Type of change

- [x] Fix
- [ ] Feature
- [ ] Other [Change this text with the reason]
- [ ] This change requires a documentation update (If checked paste PR link on [Resources](#resources))

## Comments

Comments not related to the summary.

## Resources

Links to Issues, other repositories, etc.