### PR TITLE
Updated RookSDK pod to 1.4.3

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2,11 +2,11 @@ PODS:
   - Flutter (1.0.0)
   - rook_sdk_apple_health (0.0.1):
     - Flutter
-    - RookSDK (= 1.4.2)
+    - RookSDK (= 1.4.3)
     - SwiftProtobuf (= 1.21.0)
   - RookAppleHealth (1.6.1)
   - RookConnectTransmission (1.3.0)
-  - RookSDK (1.4.2):
+  - RookSDK (1.4.3):
     - RookAppleHealth (= 1.6.1)
     - RookConnectTransmission (= 1.3.0)
     - RookUsersSDK (= 1.1.0)
@@ -44,10 +44,10 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
-  rook_sdk_apple_health: a39839ef9da3c75f6dff4ea5574682dac5abd850
+  rook_sdk_apple_health: ca6611d8a3668c4209415eac35da243ee0655048
   RookAppleHealth: 420682f89499b2226896130e7c93d959a2d71395
   RookConnectTransmission: d10a27d707b13f9d4780d161054c1f77081a04b1
-  RookSDK: a5cfa9cf361b6fbd1fb6e225a21024c12adb7fc8
+  RookSDK: 680899f51de3a2a594240804971609ad872d955a
   RookUsersSDK: 79eebc95ef4779692d247d30d89c9ec2b59a36c6
   shared_preferences_foundation: b4c3b4cddf1c21f02770737f147a3f5da9d39695
   SwiftProtobuf: afced68785854575756db965e9da52bbf3dc45e7

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2,15 +2,18 @@ PODS:
   - Flutter (1.0.0)
   - rook_sdk_apple_health (0.0.1):
     - Flutter
-    - RookSDK (= 1.3.6)
+    - RookSDK (= 1.4.2)
     - SwiftProtobuf (= 1.21.0)
-  - RookAppleHealth (1.5.3)
-  - RookConnectTransmission (1.2.8)
-  - RookSDK (1.3.6):
-    - RookAppleHealth (= 1.5.3)
-    - RookConnectTransmission (= 1.2.8)
-    - RookUsersSDK (= 1.0.6)
-  - RookUsersSDK (1.0.6)
+  - RookAppleHealth (1.6.1)
+  - RookConnectTransmission (1.3.0)
+  - RookSDK (1.4.2):
+    - RookAppleHealth (= 1.6.1)
+    - RookConnectTransmission (= 1.3.0)
+    - RookUsersSDK (= 1.1.0)
+  - RookUsersSDK (1.1.0)
+  - shared_preferences_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
   - SwiftProtobuf (1.21.0)
   - url_launcher_ios (0.0.1):
     - Flutter
@@ -18,6 +21,7 @@ PODS:
 DEPENDENCIES:
   - Flutter (from `Flutter`)
   - rook_sdk_apple_health (from `.symlinks/plugins/rook_sdk_apple_health/ios`)
+  - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
 
 SPEC REPOS:
@@ -33,16 +37,19 @@ EXTERNAL SOURCES:
     :path: Flutter
   rook_sdk_apple_health:
     :path: ".symlinks/plugins/rook_sdk_apple_health/ios"
+  shared_preferences_foundation:
+    :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
   url_launcher_ios:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
-  rook_sdk_apple_health: da4a3538f28c753a563739d9bbc2339697ec3bd7
-  RookAppleHealth: 828810c4833aeb553569c8d865b42ceb35069120
-  RookConnectTransmission: 534a45a34f6d5bfe5d674f5c0e307d534fb8040d
-  RookSDK: 72a959d1900c5b72dd7724c649a670e6fe944414
-  RookUsersSDK: 153915e39c992b7bd7291925290dce341ddefd4e
+  rook_sdk_apple_health: a39839ef9da3c75f6dff4ea5574682dac5abd850
+  RookAppleHealth: 420682f89499b2226896130e7c93d959a2d71395
+  RookConnectTransmission: d10a27d707b13f9d4780d161054c1f77081a04b1
+  RookSDK: a5cfa9cf361b6fbd1fb6e225a21024c12adb7fc8
+  RookUsersSDK: 79eebc95ef4779692d247d30d89c9ec2b59a36c6
+  shared_preferences_foundation: b4c3b4cddf1c21f02770737f147a3f5da9d39695
   SwiftProtobuf: afced68785854575756db965e9da52bbf3dc45e7
   url_launcher_ios: 08a3dfac5fb39e8759aeb0abbd5d9480f30fc8b4
 

--- a/packages/rook_sdk_apple_health/CHANGELOG.md
+++ b/packages/rook_sdk_apple_health/CHANGELOG.md
@@ -1,3 +1,3 @@
-## 0.4.2
+## 0.4.3
 
 This changelog was moved to our official documentation [page](https://docs.tryrook.io/docs/category/sdks)

--- a/packages/rook_sdk_apple_health/ios/Classes/RookSdkAppleHealthPlugin.swift
+++ b/packages/rook_sdk_apple_health/ios/Classes/RookSdkAppleHealthPlugin.swift
@@ -6,7 +6,7 @@ import RookConnectTransmission
 
 public class RookSdkAppleHealthPlugin: NSObject, FlutterPlugin {
     private let rookConnectPermissionsManager = RookConnectPermissionsManager()
-    private let rookSummaryManager = RookSummaryManger()
+    private let rookSummaryManager = RookSummaryManager()
     private let rookEventsManager = RookEventsManager()
     private let rookVariableExtractionManager = RookVariableExtractionManager()
     
@@ -47,7 +47,7 @@ public class RookSdkAppleHealthPlugin: NSObject, FlutterPlugin {
                 switch it {
                 case Result.success(let userID):
                     result(userID)
-                case Result.failure(let error):
+                case Result.failure(_):
                     result(nil)
                 }
             }

--- a/packages/rook_sdk_apple_health/ios/rook_sdk_apple_health.podspec
+++ b/packages/rook_sdk_apple_health/ios/rook_sdk_apple_health.podspec
@@ -15,7 +15,7 @@ A new Flutter plugin project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'RookSDK', '1.3.6'
+  s.dependency 'RookSDK', '1.4.2'
   s.dependency 'SwiftProtobuf', '1.21.0'
   s.platform = :ios, '13.0'
 

--- a/packages/rook_sdk_apple_health/ios/rook_sdk_apple_health.podspec
+++ b/packages/rook_sdk_apple_health/ios/rook_sdk_apple_health.podspec
@@ -15,7 +15,7 @@ A new Flutter plugin project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'RookSDK', '1.4.2'
+  s.dependency 'RookSDK', '1.4.3'
   s.dependency 'SwiftProtobuf', '1.21.0'
   s.platform = :ios, '13.0'
 

--- a/packages/rook_sdk_apple_health/playground/ios/Podfile.lock
+++ b/packages/rook_sdk_apple_health/playground/ios/Podfile.lock
@@ -4,15 +4,15 @@ PODS:
     - Flutter
   - rook_sdk_apple_health (0.0.1):
     - Flutter
-    - RookSDK (= 1.3.6)
+    - RookSDK (= 1.4.2)
     - SwiftProtobuf (= 1.21.0)
-  - RookAppleHealth (1.5.3)
-  - RookConnectTransmission (1.2.8)
-  - RookSDK (1.3.6):
-    - RookAppleHealth (= 1.5.3)
-    - RookConnectTransmission (= 1.2.8)
-    - RookUsersSDK (= 1.0.6)
-  - RookUsersSDK (1.0.6)
+  - RookAppleHealth (1.6.1)
+  - RookConnectTransmission (1.3.0)
+  - RookSDK (1.4.2):
+    - RookAppleHealth (= 1.6.1)
+    - RookConnectTransmission (= 1.3.0)
+    - RookUsersSDK (= 1.1.0)
+  - RookUsersSDK (1.1.0)
   - SwiftProtobuf (1.21.0)
 
 DEPENDENCIES:
@@ -39,11 +39,11 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   integration_test: 13825b8a9334a850581300559b8839134b124670
-  rook_sdk_apple_health: da4a3538f28c753a563739d9bbc2339697ec3bd7
-  RookAppleHealth: 828810c4833aeb553569c8d865b42ceb35069120
-  RookConnectTransmission: 534a45a34f6d5bfe5d674f5c0e307d534fb8040d
-  RookSDK: 72a959d1900c5b72dd7724c649a670e6fe944414
-  RookUsersSDK: 153915e39c992b7bd7291925290dce341ddefd4e
+  rook_sdk_apple_health: a39839ef9da3c75f6dff4ea5574682dac5abd850
+  RookAppleHealth: 420682f89499b2226896130e7c93d959a2d71395
+  RookConnectTransmission: d10a27d707b13f9d4780d161054c1f77081a04b1
+  RookSDK: a5cfa9cf361b6fbd1fb6e225a21024c12adb7fc8
+  RookUsersSDK: 79eebc95ef4779692d247d30d89c9ec2b59a36c6
   SwiftProtobuf: afced68785854575756db965e9da52bbf3dc45e7
 
 PODFILE CHECKSUM: 70d9d25280d0dd177a5f637cdb0f0b0b12c6a189

--- a/packages/rook_sdk_apple_health/playground/ios/Podfile.lock
+++ b/packages/rook_sdk_apple_health/playground/ios/Podfile.lock
@@ -4,11 +4,11 @@ PODS:
     - Flutter
   - rook_sdk_apple_health (0.0.1):
     - Flutter
-    - RookSDK (= 1.4.2)
+    - RookSDK (= 1.4.3)
     - SwiftProtobuf (= 1.21.0)
   - RookAppleHealth (1.6.1)
   - RookConnectTransmission (1.3.0)
-  - RookSDK (1.4.2):
+  - RookSDK (1.4.3):
     - RookAppleHealth (= 1.6.1)
     - RookConnectTransmission (= 1.3.0)
     - RookUsersSDK (= 1.1.0)
@@ -39,10 +39,10 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   integration_test: 13825b8a9334a850581300559b8839134b124670
-  rook_sdk_apple_health: a39839ef9da3c75f6dff4ea5574682dac5abd850
+  rook_sdk_apple_health: ca6611d8a3668c4209415eac35da243ee0655048
   RookAppleHealth: 420682f89499b2226896130e7c93d959a2d71395
   RookConnectTransmission: d10a27d707b13f9d4780d161054c1f77081a04b1
-  RookSDK: a5cfa9cf361b6fbd1fb6e225a21024c12adb7fc8
+  RookSDK: 680899f51de3a2a594240804971609ad872d955a
   RookUsersSDK: 79eebc95ef4779692d247d30d89c9ec2b59a36c6
   SwiftProtobuf: afced68785854575756db965e9da52bbf3dc45e7
 

--- a/packages/rook_sdk_apple_health/pubspec.yaml
+++ b/packages/rook_sdk_apple_health/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rook_sdk_apple_health
 description: This package enables apps to extract and upload data from Apple Health.
-version: 0.4.2
+version: 0.4.3
 homepage: 'https://docs.tryrook.io/'
 platforms:
   ios:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -230,7 +230,7 @@ packages:
       path: "packages/rook_sdk_apple_health"
       relative: true
     source: path
-    version: "0.4.2"
+    version: "0.4.3"
   rook_sdk_core:
     dependency: "direct main"
     description:


### PR DESCRIPTION
# Pull request

## Summary

Updated RookSDK pod to 1.4.3 which contains internal fixes for:

* always null _active_seconds_ bug.  
* old xcode versions incompatibilities

## Type of change

- [x] Fix
- [ ] Feature
- [ ] Other [Change this text with the reason]
- [ ] This change requires a documentation update (If checked paste PR link on [Resources](#resources))

## Comments

Comments not related to the summary.

## Resources

Links to Issues, other repositories, etc.