### PR TITLE
Sync with develop

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -4,9 +4,9 @@ PODS:
   - Flutter (1.0.0)
   - rook_sdk_apple_health (0.0.1):
     - Flutter
-    - RookSDK (= 1.5.8)
+    - RookSDK (= 1.6.0)
     - SwiftProtobuf (= 1.21.0)
-  - RookSDK (1.5.8)
+  - RookSDK (1.6.0)
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -41,8 +41,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   app_settings: 017320c6a680cdc94c799949d95b84cb69389ebc
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
-  rook_sdk_apple_health: c462932fd617a3f0808defd55a3bb00fcc843688
-  RookSDK: d979ea4f6b4199360bcb41501361eca17e792223
+  rook_sdk_apple_health: 52788e48bf7e63b5eb20a75c343353b642501178
+  RookSDK: 3fa0b38edbe85131e7361d0b84511fe29aec0c33
   shared_preferences_foundation: b4c3b4cddf1c21f02770737f147a3f5da9d39695
   SwiftProtobuf: afced68785854575756db965e9da52bbf3dc45e7
   url_launcher_ios: 08a3dfac5fb39e8759aeb0abbd5d9480f30fc8b4

--- a/packages/rook_sdk_apple_health/CHANGELOG.md
+++ b/packages/rook_sdk_apple_health/CHANGELOG.md
@@ -1,3 +1,3 @@
-## 1.2.1
+## 1.2.2
 
 This changelog was moved to our official documentation [page](https://docs.tryrook.io/docs/category/sdks)

--- a/packages/rook_sdk_apple_health/ios/Classes/RookSdkAppleHealthPlugin.swift
+++ b/packages/rook_sdk_apple_health/ios/Classes/RookSdkAppleHealthPlugin.swift
@@ -35,7 +35,8 @@ public class RookSdkAppleHealthPlugin: NSObject, FlutterPlugin {
                     RookConnectConfigurationManager.shared.setConfiguration(
                         clientUUID: it.clientUuid,
                         secretKey: it.secretKey,
-                        enableBackgroundSync: it.enableBackgroundSync
+                        enableBackgroundSync: it.enableBackgroundSync,
+                        enableEventsBackgroundSync: it.enableBackgroundSync
                     )
                     
                     resultBoolSuccess(flutterResult: result, true)
@@ -319,7 +320,8 @@ public class RookSdkAppleHealthPlugin: NSObject, FlutterPlugin {
                     RookConnectConfigurationManager.shared.setConfiguration(
                         clientUUID: it.clientUuid,
                         secretKey: it.secretKey,
-                        enableBackgroundSync: true
+                        enableBackgroundSync: true,
+                        enableEventsBackgroundSync: true
                     )
                     
                     RookConnectConfigurationManager.shared.initRook { it in
@@ -353,7 +355,8 @@ public class RookSdkAppleHealthPlugin: NSObject, FlutterPlugin {
                     RookConnectConfigurationManager.shared.setConfiguration(
                         clientUUID: it.clientUuid,
                         secretKey: it.secretKey,
-                        enableBackgroundSync: true
+                        enableBackgroundSync: true,
+                        enableEventsBackgroundSync: true
                     )
                     
                     RookConnectConfigurationManager.shared.initRook { it in

--- a/packages/rook_sdk_apple_health/ios/rook_sdk_apple_health.podspec
+++ b/packages/rook_sdk_apple_health/ios/rook_sdk_apple_health.podspec
@@ -15,7 +15,7 @@ A new Flutter plugin project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'RookSDK', '1.5.8'
+  s.dependency 'RookSDK', '1.6.0'
   s.dependency 'SwiftProtobuf', '1.21.0'
   s.platform = :ios, '13.0'
 

--- a/packages/rook_sdk_apple_health/playground/ios/Podfile.lock
+++ b/packages/rook_sdk_apple_health/playground/ios/Podfile.lock
@@ -4,9 +4,9 @@ PODS:
     - Flutter
   - rook_sdk_apple_health (0.0.1):
     - Flutter
-    - RookSDK (= 1.5.8)
+    - RookSDK (= 1.6.0)
     - SwiftProtobuf (= 1.21.0)
-  - RookSDK (1.5.8)
+  - RookSDK (1.6.0)
   - SwiftProtobuf (1.21.0)
 
 DEPENDENCIES:
@@ -30,8 +30,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   integration_test: 13825b8a9334a850581300559b8839134b124670
-  rook_sdk_apple_health: c462932fd617a3f0808defd55a3bb00fcc843688
-  RookSDK: d979ea4f6b4199360bcb41501361eca17e792223
+  rook_sdk_apple_health: 52788e48bf7e63b5eb20a75c343353b642501178
+  RookSDK: 3fa0b38edbe85131e7361d0b84511fe29aec0c33
   SwiftProtobuf: afced68785854575756db965e9da52bbf3dc45e7
 
 PODFILE CHECKSUM: 868a8e850aa5b3edf4dbe97c50064ccbd51cf91b

--- a/packages/rook_sdk_apple_health/pubspec.yaml
+++ b/packages/rook_sdk_apple_health/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rook_sdk_apple_health
 description: This package enables apps to extract and upload data from Apple Health.
-version: 1.2.1
+version: 1.2.2
 homepage: 'https://docs.tryrook.io/'
 platforms:
   ios:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -238,7 +238,7 @@ packages:
       path: "packages/rook_sdk_apple_health"
       relative: true
     source: path
-    version: "1.2.1"
+    version: "1.2.2"
   rook_sdk_core:
     dependency: "direct main"
     description:


### PR DESCRIPTION
# Pull request

## Summary

### Apple Health 1.2.2

* Temperature events bug fixed
* 30 days history for first time sync
* Events background and summary background independent activation and deactivation

Dependency updates

* RookSDK (COCOAPODS): **1.5.8** → **1.6.0**

**Before running your app you MUST run `pod install` or `pod update` in your **/ios** directory**

## Type of change

- [x] Fix
- [x] Feature
- [ ] Other [Change this text with the reason]
- [ ] This change requires a documentation update (If checked paste PR link on [Resources](#resources))

## Comments

Comments not related to the summary.

## Resources

Links to Issues, other repositories, etc.