### PR TITLE
Health Connect rate limit optimizations

### DIFF
--- a/packages/rook_sdk_health_connect/CHANGELOG.md
+++ b/packages/rook_sdk_health_connect/CHANGELOG.md
@@ -1,3 +1,3 @@
-## 3.0.0
+## 3.1.0
 
 This changelog was moved to our official documentation [page](https://docs.tryrook.io/docs/category/sdks)

--- a/packages/rook_sdk_health_connect/android/build.gradle
+++ b/packages/rook_sdk_health_connect/android/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 // ------------------------ Dependencies ------------------------
-String rookSdkVersion = "2.0.0"
+String rookSdkVersion = "2.1.0"
 String protoVersion = "4.28.3"
 String timberVersion = "5.0.1"
 // ------------------------ Dependencies ------------------------

--- a/packages/rook_sdk_health_connect/android/src/main/kotlin/com/rookmotion/rook_sdk_health_connect/eventhandler/IsScheduledTransmitter.kt
+++ b/packages/rook_sdk_health_connect/android/src/main/kotlin/com/rookmotion/rook_sdk_health_connect/eventhandler/IsScheduledTransmitter.kt
@@ -42,6 +42,6 @@ class IsScheduledTransmitter(
     }
 
     companion object {
-        const val EVENT_CHANNEL_NAME = "io.tryrook.background.scheduled"
+        const val EVENT_CHANNEL_NAME = "io.tryrook.background.healthconnect.scheduled"
     }
 }

--- a/packages/rook_sdk_health_connect/lib/src/data/mapper/availability_status_mappers.dart
+++ b/packages/rook_sdk_health_connect/lib/src/data/mapper/availability_status_mappers.dart
@@ -7,6 +7,8 @@ extension AvailabilityStatusMappers on AvailabilityStatusProto {
       AvailabilityStatusProto.INSTALLED => HCAvailabilityStatus.installed,
       AvailabilityStatusProto.NOT_INSTALLED =>
         HCAvailabilityStatus.notInstalled,
+      AvailabilityStatusProto.NOT_SUPPORTED =>
+        HCAvailabilityStatus.notSupported,
       _ => throw Exception('Unknown availability status: $this'),
     };
   }

--- a/packages/rook_sdk_health_connect/lib/src/data/mapper/availability_status_mappers.dart
+++ b/packages/rook_sdk_health_connect/lib/src/data/mapper/availability_status_mappers.dart
@@ -7,7 +7,7 @@ extension AvailabilityStatusMappers on AvailabilityStatusProto {
       AvailabilityStatusProto.INSTALLED => HCAvailabilityStatus.installed,
       AvailabilityStatusProto.NOT_INSTALLED =>
         HCAvailabilityStatus.notInstalled,
-      _ => HCAvailabilityStatus.notSupported,
+      _ => throw Exception('Unknown availability status: $this'),
     };
   }
 }

--- a/packages/rook_sdk_health_connect/lib/src/domain/model/health_connect_permissions_summary.dart
+++ b/packages/rook_sdk_health_connect/lib/src/domain/model/health_connect_permissions_summary.dart
@@ -2,7 +2,7 @@
 ///
 /// * [dataTypesGranted] Whether the user granted permission to read all requested data types.
 /// * [dataTypesPartiallyGranted] Whether the user granted permission to read at least one requested data type.
-/// Note that if [dataTypesGranted] is true, this will wwalso be true.
+/// Note that if [dataTypesGranted] is true, this will also be true.
 /// * [backgroundReadGranted] Whether the user granted background read permission.
 class HealthConnectPermissionsSummary {
   final bool dataTypesGranted;

--- a/packages/rook_sdk_health_connect/lib/src/hc_rook_sync_manager.dart
+++ b/packages/rook_sdk_health_connect/lib/src/hc_rook_sync_manager.dart
@@ -6,6 +6,11 @@ import 'package:rook_sdk_health_connect/src/platform/rook_sdk_health_connect_pla
 class HCRookSyncManager {
   HCRookSyncManager._();
 
+  /// Syncs summaries using the provided parameters.
+  ///
+  /// If [enableLogs] is not null: Syncs the last 29 days of SLEEP_SUMMARY, PHYSICAL_SUMMARY and BODY_SUMMARY (not including today).
+  /// If [date] is not null: Syncs SLEEP_SUMMARY, PHYSICAL_SUMMARY and BODY_SUMMARY for the provided [date].
+  /// if [summary] and [date] are not null: Syncs the [summary] of choice for the provided [date].
   static Future<bool> sync({
     bool? enableLogs,
     DateTime? date,
@@ -33,6 +38,7 @@ class HCRookSyncManager {
     throw UnsupportedError('At least one parameter is required');
   }
 
+  /// Syncs the [event] of choice for the provided [date].
   static Future<bool> syncEvents(DateTime date, HCEventSyncType event) {
     return RookSdkHealthConnectPlatform.instance.syncByDateAndEvent(
       date,
@@ -40,10 +46,20 @@ class HCRookSyncManager {
     );
   }
 
+  /// Retrieve and upload current day steps count of Health Connect.
+  ///
+  /// **Warning: This function contributes to the Health Connect rate limit, don't call it too frequently.**
+  ///
+  /// Returns a [SyncStatusWithData] with the current day steps count (if available).
   static Future<SyncStatusWithData<int>> getTodayStepsCount() {
     return RookSdkHealthConnectPlatform.instance.getTodayStepsCount();
   }
 
+  /// Retrieve and upload current day calories count of Health Connect.
+  ///
+  /// **Warning: This function contributes to the Health Connect rate limit, don't call it too frequently.**
+  ///
+  /// Returns a [SyncStatusWithData] with the current day calories count (if available).
   static Future<SyncStatusWithData<DailyCalories>> getTodayCaloriesCount() {
     return RookSdkHealthConnectPlatform.instance.getTodayCaloriesCount();
   }

--- a/packages/rook_sdk_health_connect/lib/src/platform/rook_sdk_health_connect_method_channel.dart
+++ b/packages/rook_sdk_health_connect/lib/src/platform/rook_sdk_health_connect_method_channel.dart
@@ -37,7 +37,7 @@ class MethodChannelRookSdkHealthConnect extends RookSdkHealthConnectPlatform {
 
   @visibleForTesting
   final isScheduledEventChannel = const EventChannel(
-    "io.tryrook.background.scheduled",
+    "io.tryrook.background.healthconnect.scheduled",
   );
 
   @override

--- a/packages/rook_sdk_health_connect/playground/android/app/build.gradle
+++ b/packages/rook_sdk_health_connect/playground/android/app/build.gradle
@@ -4,24 +4,6 @@ plugins {
     id "dev.flutter.flutter-gradle-plugin"
 }
 
-def localProperties = new Properties()
-def localPropertiesFile = rootProject.file('local.properties')
-if (localPropertiesFile.exists()) {
-    localPropertiesFile.withReader('UTF-8') { reader ->
-        localProperties.load(reader)
-    }
-}
-
-def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
-if (flutterVersionCode == null) {
-    flutterVersionCode = '1'
-}
-
-def flutterVersionName = localProperties.getProperty('flutter.versionName')
-if (flutterVersionName == null) {
-    flutterVersionName = '1.0'
-}
-
 android {
     namespace "com.rookmotion.rook_sdk_health_connect_example"
     compileSdk 35
@@ -44,8 +26,8 @@ android {
         applicationId "com.rookmotion.rook_sdk_health_connect_example"
         minSdk 26
         targetSdk 35
-        versionCode flutterVersionCode.toInteger()
-        versionName flutterVersionName
+        versionCode 1
+        versionName "1.0"
     }
 
     buildTypes {

--- a/packages/rook_sdk_health_connect/pubspec.yaml
+++ b/packages/rook_sdk_health_connect/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rook_sdk_health_connect
 description: This package enables apps to extract and upload data from Health Connect.
-version: 3.0.0
+version: 3.1.0
 homepage: 'https://docs.tryrook.io/'
 platforms:
   android:

--- a/packages/rook_sdk_health_connect/test/src/platform/rook_sdk_health_connect_method_channel_test.dart
+++ b/packages/rook_sdk_health_connect/test/src/platform/rook_sdk_health_connect_method_channel_test.dart
@@ -101,6 +101,15 @@ void resultBooleanTests(
     );
 
     test(
+      'GIVEN the happy path WHEN checkHealthConnectPermissionsPartially THEN complete with expected value',
+      () async {
+        final future = platform.checkHealthConnectPermissionsPartially();
+
+        await expectLater(future, completion(true));
+      },
+    );
+
+    test(
       'GIVEN the happy path WHEN syncPendingSummaries THEN complete',
       () async {
         final future = platform.syncPendingSummaries();
@@ -304,6 +313,15 @@ void resultBooleanTests(
       'GIVEN the unhappy path WHEN checkHealthConnectPermissions THEN throw exception',
       () async {
         final future = platform.checkHealthConnectPermissions();
+
+        await expectLater(future, throwsA(isException));
+      },
+    );
+
+    test(
+      'GIVEN the unhappy path WHEN checkHealthConnectPermissionsPartially THEN throw exception',
+      () async {
+        final future = platform.checkHealthConnectPermissionsPartially();
 
         await expectLater(future, throwsA(isException));
       },

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -268,7 +268,7 @@ packages:
       path: "packages/rook_sdk_health_connect"
       relative: true
     source: path
-    version: "3.0.0"
+    version: "3.1.0"
   shared_preferences:
     dependency: "direct main"
     description:


### PR DESCRIPTION
# Pull request

## Summary

* Reduced the recovery time that automatic syncs will wait before syncing again when Health Connect rate limit is exceeded to 45 minutes.
* Fewer restrictions on manual syncs after Health Connect rate limit is exceeded.
* Optimized metadata logging
* Optimized time zone syncing

## Type of change

- [x] Fix
- [ ] Feature
- [x] Optimizations
- [ ] This change requires a documentation update (If checked paste PR link on [Resources](#resources))

## Comments

Comments not related to the summary.

## Resources

Links to Issues, other repositories, etc.