### PR TITLE
Health Connect 3.2.0 | Apple Health 1.9.0

### DIFF
--- a/packages/rook_sdk_apple_health/CHANGELOG.md
+++ b/packages/rook_sdk_apple_health/CHANGELOG.md
@@ -1,3 +1,3 @@
-## 1.8.1
+## 1.9.0
 
 This changelog was moved to our official documentation [page](https://docs.tryrook.io/docs/category/sdks)

--- a/packages/rook_sdk_apple_health/pubspec.yaml
+++ b/packages/rook_sdk_apple_health/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rook_sdk_apple_health
 description: This package enables apps to extract and upload data from Apple Health.
-version: 1.8.1
+version: 1.9.0
 homepage: 'https://docs.tryrook.io/'
 platforms:
   ios:
@@ -15,11 +15,11 @@ dependencies:
   plugin_platform_interface: ">=2.0.0 <3.0.0"
   protobuf: ">=3.0.0 <4.0.0"
   fixnum: "^1.0.0"
-  rook_sdk_core: "^1.0.0"
+  rook_sdk_core: "^1.1.0"
 
-dependency_overrides:
-  rook_sdk_core:
-    path: "../rook_sdk_core"
+#dependency_overrides:
+#  rook_sdk_core:
+#    path: "../rook_sdk_core"
 
 dev_dependencies:
   flutter_test:

--- a/packages/rook_sdk_health_connect/CHANGELOG.md
+++ b/packages/rook_sdk_health_connect/CHANGELOG.md
@@ -1,3 +1,3 @@
-## 3.1.0
+## 3.2.0
 
 This changelog was moved to our official documentation [page](https://docs.tryrook.io/docs/category/sdks)

--- a/packages/rook_sdk_health_connect/pubspec.yaml
+++ b/packages/rook_sdk_health_connect/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rook_sdk_health_connect
 description: This package enables apps to extract and upload data from Health Connect.
-version: 3.1.0
+version: 3.2.0
 homepage: 'https://docs.tryrook.io/'
 platforms:
   android:
@@ -15,11 +15,11 @@ dependencies:
   plugin_platform_interface: ">=2.0.0 <3.0.0"
   protobuf: ">=3.0.0 <4.0.0"
   fixnum: "^1.0.0"
-  rook_sdk_core: "^1.0.0"
+  rook_sdk_core: "^1.1.0"
 
-dependency_overrides:
-  rook_sdk_core:
-    path: "../rook_sdk_core"
+#dependency_overrides:
+#  rook_sdk_core:
+#    path: "../rook_sdk_core"
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -254,7 +254,7 @@ packages:
       path: "packages/rook_sdk_apple_health"
       relative: true
     source: path
-    version: "1.8.1"
+    version: "1.9.0"
   rook_sdk_core:
     dependency: "direct main"
     description:
@@ -268,7 +268,7 @@ packages:
       path: "packages/rook_sdk_health_connect"
       relative: true
     source: path
-    version: "3.1.0"
+    version: "3.2.0"
   rook_sdk_samsung_health:
     dependency: "direct main"
     description:


### PR DESCRIPTION
# Pull request

## Summary

* Updated Health Connect version to 3.2.0
* Updated Apple Health version to 1.9.0
* Updated core sdk internal version to 1.1.0 in Health Connect and Apple Health

## Type of change

- [ ] Fix
- [x] Feature
- [ ] Other [Change this text with the reason]
- [ ] This change requires a documentation update (If checked paste PR link on [Resources](#resources))

## Comments

Comments not related to the summary.

## Resources

Links to Issues, other repositories, etc.