### PR TITLE
Updated RookSDK to 1.7.8

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -4,9 +4,9 @@ PODS:
   - Flutter (1.0.0)
   - rook_sdk_apple_health (0.0.1):
     - Flutter
-    - RookSDK (= 1.7.7)
+    - RookSDK (= 1.7.8)
     - SwiftProtobuf (= 1.28.2)
-  - RookSDK (1.7.7)
+  - RookSDK (1.7.8)
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -41,8 +41,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   app_settings: 58017cd26b604ae98c3e65acbdd8ba173703cc82
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  rook_sdk_apple_health: bb6e6ad4fe2241b233b0ad0ac2ddf97c3dc41bb0
-  RookSDK: 2f571dbf31018400b3582058b110ae4461a7b166
+  rook_sdk_apple_health: c4ef9e92f2174fcc2d355356634898279148f155
+  RookSDK: 880f9471caa7d4c435d62c3ece2107bd5383b737
   shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
   SwiftProtobuf: 4dbaffec76a39a8dc5da23b40af1a5dc01a4c02d
   url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe

--- a/packages/rook_sdk_apple_health/CHANGELOG.md
+++ b/packages/rook_sdk_apple_health/CHANGELOG.md
@@ -1,3 +1,3 @@
-## 1.9.0
+## 1.9.1
 
 This changelog was moved to our official documentation [page](https://docs.tryrook.io/docs/category/sdks)

--- a/packages/rook_sdk_apple_health/ios/rook_sdk_apple_health.podspec
+++ b/packages/rook_sdk_apple_health/ios/rook_sdk_apple_health.podspec
@@ -15,7 +15,7 @@ A new Flutter plugin project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'RookSDK', '1.7.7'
+  s.dependency 'RookSDK', '1.7.8'
   s.dependency 'SwiftProtobuf', '1.28.2'
   s.platform = :ios, '13.0'
 

--- a/packages/rook_sdk_apple_health/playground/ios/Podfile.lock
+++ b/packages/rook_sdk_apple_health/playground/ios/Podfile.lock
@@ -4,9 +4,9 @@ PODS:
     - Flutter
   - rook_sdk_apple_health (0.0.1):
     - Flutter
-    - RookSDK (= 1.7.7)
+    - RookSDK (= 1.7.8)
     - SwiftProtobuf (= 1.28.2)
-  - RookSDK (1.7.7)
+  - RookSDK (1.7.8)
   - SwiftProtobuf (1.28.2)
 
 DEPENDENCIES:
@@ -30,8 +30,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
-  rook_sdk_apple_health: bb6e6ad4fe2241b233b0ad0ac2ddf97c3dc41bb0
-  RookSDK: 2f571dbf31018400b3582058b110ae4461a7b166
+  rook_sdk_apple_health: c4ef9e92f2174fcc2d355356634898279148f155
+  RookSDK: 880f9471caa7d4c435d62c3ece2107bd5383b737
   SwiftProtobuf: 4dbaffec76a39a8dc5da23b40af1a5dc01a4c02d
 
 PODFILE CHECKSUM: 26885315ab971dcfca5c3f7273ed74a8975f75ac

--- a/packages/rook_sdk_apple_health/pubspec.yaml
+++ b/packages/rook_sdk_apple_health/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rook_sdk_apple_health
 description: This package enables apps to extract and upload data from Apple Health.
-version: 1.9.0
+version: 1.9.1
 homepage: 'https://docs.tryrook.io/'
 platforms:
   ios:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -254,7 +254,7 @@ packages:
       path: "packages/rook_sdk_apple_health"
       relative: true
     source: path
-    version: "1.9.0"
+    version: "1.9.1"
   rook_sdk_core:
     dependency: "direct main"
     description:
@@ -268,7 +268,7 @@ packages:
       path: "packages/rook_sdk_health_connect"
       relative: true
     source: path
-    version: "3.2.0"
+    version: "3.2.1"
   rook_sdk_samsung_health:
     dependency: "direct main"
     description:


### PR DESCRIPTION
# Pull request

## Summary

Fixed crash on IOS 16 for old iPhones

## Type of change

- [x] Fix
- [ ] Feature
- [ ] Other [Change this text with the reason]
- [ ] This change requires a documentation update (If checked paste PR link on [Resources](#resources))

## Comments

Comments not related to the summary.

## Resources

Links to Issues, other repositories, etc.